### PR TITLE
Updated to fix creationTime

### DIFF
--- a/protocolbuffers.inc.php
+++ b/protocolbuffers.inc.php
@@ -137,13 +137,8 @@ class Protobuf {
 		if ($limit !== null)
 			$limit -= $len;
 
-		$i = 0;
-		$shift = 0;
-		for ($j = 0; $j < $len; $j++) {
-			$i |= ((ord($value[$j]) & 0x7F) << $shift);
-			$shift += 7;
-		}
-
+		$i = 0.0;
+		for ($j = $len-1; $j >= 0; $j--)$i = $i * 128 + (ord($value[$j]) & 0x7F);
 		return $i;
 	}
 


### PR DESCRIPTION
At least in 32 bit systems the getCreationTime() method on a comment returns invalid values, sometimes even negative values!

I've altered the following code inside the file protocolbuffers.inc.php :

I've replaced: 
$i = 0;
$shift = 0;
for ($j = 0; $j < $len; $j++) {
$i |= ((ord($value[$j]) & 0x7F) << $shift);
$shift += 7;
}
By:
$i = 0.0;
for ($j = $len-1; $j >= 0; $j--) $i = $i * 128 + (ord($value[$j]) & 0x7F);

Now the command date("Y-m-d H:i:s",$comment->getCreationTime()/1000) returns the correct date!